### PR TITLE
Changed "via" links on posts

### DIFF
--- a/application/controllers/home.php
+++ b/application/controllers/home.php
@@ -77,7 +77,7 @@ class Home extends Dashboard_Controller
 		
 				if ($activity->site_id != config_item('site_id'))
 				{
-					$this->data['item_source']		= ' via <a href="'.prep_url($activity->url).'" target="_blank">'.$activity->title.'</a>';
+					$this->data['item_source']		= ' via <a href="'.prep_url(property_exists($activity,'canonical')&&$activity->canonical?$activity->canonical:$activity->url).'" target="_blank">'.$activity->title.'</a>';
 				}
 
 

--- a/application/models/activity_model.php
+++ b/application/models/activity_model.php
@@ -9,10 +9,11 @@ class Activity_model extends CI_Model
     
     function get_timeline($where, $limit)
     {
- 		$this->db->select('activity.*, sites.url, sites.title, sites.favicon, users.username, users.gravatar, users.name, users.image');
+ 		$this->db->select('activity.*, content.canonical, sites.url, sites.title, sites.favicon, users.username, users.gravatar, users.name, users.image');
  		$this->db->from('activity');    
  		$this->db->join('sites', 'sites.site_id = activity.site_id');
  		$this->db->join('users', 'users.user_id = activity.user_id'); 				
+ 		$this->db->join('content', 'content.content_id = activity.content_id'); 				
     	$this->db->where($where);
 	 	$this->db->where('activity.status !=', 'D');    	
  		$this->db->order_by('created_at', 'desc'); 


### PR DESCRIPTION
Activities' "via" links now link to the canonical version of the item if available, and fall back to the website if no canonical version exists.
